### PR TITLE
support for cordova hot code push

### DIFF
--- a/lib/server.jsx
+++ b/lib/server.jsx
@@ -23,6 +23,10 @@ function IsAppUrl(req) {
     return false;
   }
 
+  if(url.startsWith('/__cordova') {
+    return false;
+  }
+     
   // Avoid serving app HTML for declared routes such as /sockjs/.
   if(RoutePolicy.classify(url)) {
     return false;


### PR DESCRIPTION
assets for hot code push are served from /__cordova
currently it doesnt work since this path returns Not Found